### PR TITLE
Votes should not factor in abstentions

### DIFF
--- a/roll-call.go
+++ b/roll-call.go
@@ -206,7 +206,7 @@ func stopRollCall(s *discordgo.Session, channelID string) (bool, error) {
 
 	if len(rollCall.votes) == 0 {
 		motionPassed = false
-	} else if float64(ayes)/float64(total) <= passReq {
+	} else if float64(ayes)/(float64(ayes)+float64(nays)) <= passReq {
 		motionPassed = false
 	}
 


### PR DESCRIPTION
Possibly incorrect formatting but should be close to what needs to be done - make the bot no longer factor in abstentions when determining if a vote passed or not.